### PR TITLE
Disable source maps for global styles

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -28,11 +28,11 @@ module.exports = {
           },
           {
             loader: 'css-loader',
-            options: { importLoaders: 1, sourceMap: true },
+            options: { importLoaders: 1, sourceMap: false },
           },
-          { loader: 'postcss-loader', options: { sourceMap: true } },
-          { loader: 'resolve-url-loader', options: { sourceMap: true } },
-          { loader: 'sass-loader', options: { sourceMap: true } },
+          'postcss-loader',
+          'resolve-url-loader',
+          'sass-loader',
         ],
       },
       {


### PR DESCRIPTION
Disable source maps for global styles. The main motivation is that `style-loader` adds source maps to the production JS (rather than emitting them as a separate file), which bloats the file size. Additionally, there are two weaker motivations:

1. `style-loader` doesn't support them when `injectType` is set to `singletonStyleTag`. However, would remove that option just as well.
2. Styled Components doesn't support source maps, so disabling them for global styles doesn't seem too bad.

If we really wanted source maps for global styles, we could do the following:

1. Disable source maps in production to keep the file size small.
2. Stop using `singletonStyleTag` (at least in development).

But unfortunately the current (recommended) strategy of having two Webpack configs, one for production and one for development, which both inherit from a common config doesn't easily support (1), because we'd need to set `module.exports.module.rules[1].use[1].options.sourceMap` based on the mode (with all the surrounding configuration being identical in both modes).