### PR TITLE
In development, enable source maps for global styles

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -22,6 +22,10 @@ module.exports = {
         test: /\.scss$/,
         exclude: /node_modules/,
         use: [
+          // Since we use Styled Components (an implementation of CSS-in-JS) to
+          // dynamically add CSS to the page, we use `style-loader` rather than
+          // the loader from `mini-css-extract-plugin` so that all the CSS loads
+          // at the same time (i.e., when the JavaScript loads).
           {
             loader: 'style-loader',
             options: { injectType: 'singletonStyleTag' },
@@ -30,9 +34,9 @@ module.exports = {
             loader: 'css-loader',
             options: { importLoaders: 1, sourceMap: false },
           },
-          'postcss-loader',
-          'resolve-url-loader',
-          'sass-loader',
+          { loader: 'postcss-loader', options: { sourceMap: true } },
+          { loader: 'resolve-url-loader', options: { sourceMap: true } },
+          { loader: 'sass-loader', options: { sourceMap: true } },
         ],
       },
       {

--- a/webpack.development.js
+++ b/webpack.development.js
@@ -1,6 +1,29 @@
 const { merge } = require('webpack-merge');
 const common = require('./webpack.common.js');
 
+// Enable source maps. We disable source maps in production because
+// `style-loader` only supports inline source maps, which lead to bloat.
+// However, that bloat is not as much of a concern in development.
+const cssLoader = common.module.rules[1].use[1];
+if (cssLoader.loader === 'css-loader') {
+  cssLoader.options.sourceMap = true;
+} else {
+  throw new Error('Please update the `cssLoader` definition above.');
+}
+
+// For production, we configure `style-loader` to emit a single `<style>` tag,
+// since it looks a little neater than the default behavior of having a separate
+// `<style>` tag for each source file. Unfortunately this breaks source maps,
+// but we disable source maps in production anyway as noted above. To enable
+// source maps in development, we have to revert the behavior to generating a
+// separate `<style>` tag for each source file.
+const styleLoader = common.module.rules[1].use[0];
+if (styleLoader.loader === 'style-loader') {
+  styleLoader.options.injectType = 'styleTag';
+} else {
+  throw new Error('Please update the `styleLoader` definition above.');
+}
+
 module.exports = merge(common, {
   mode: 'development',
 });


### PR DESCRIPTION
In development, enable source maps for global styles.

This is the implementation of the plan outlined in https://github.com/stepchowfun/webpack-scaffolding/pull/18.