### PR TITLE
Add `@babel/plugin-transform-runtime` to make async/await work

### DIFF
--- a/babel.config.json
+++ b/babel.config.json
@@ -1,5 +1,8 @@
 {
-  "plugins": ["babel-plugin-styled-components"],
+  "plugins": [
+    "babel-plugin-styled-components",
+    "@babel/plugin-transform-runtime"
+  ],
   "presets": [
     "@babel/preset-env",
     "@babel/preset-typescript",

--- a/package-lock.json
+++ b/package-lock.json
@@ -937,6 +937,18 @@
         "@babel/helper-plugin-utils": "^7.10.4"
       }
     },
+    "@babel/plugin-transform-runtime": {
+      "version": "7.11.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.11.5.tgz",
+      "integrity": "sha512-9aIoee+EhjySZ6vY5hnLjigHzunBlscx9ANKutkeWTJTx6m5Rbq6Ic01tLvO54lSusR+BxV7u4UDdCmXv5aagg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.10.4",
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "resolve": "^1.8.1",
+        "semver": "^5.5.1"
+      }
+    },
     "@babel/plugin-transform-shorthand-properties": {
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.10.4.tgz",
@@ -1156,7 +1168,6 @@
       "version": "7.11.2",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
       "integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-      "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -15230,8 +15241,7 @@
     "regenerator-runtime": {
       "version": "0.13.7",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
-      "dev": true
+      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
     },
     "regenerator-transform": {
       "version": "0.14.5",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "license": "MIT",
   "devDependencies": {
     "@babel/core": "^7.11.6",
+    "@babel/plugin-transform-runtime": "^7.11.5",
     "@babel/preset-env": "^7.11.5",
     "@babel/preset-react": "^7.10.4",
     "@babel/preset-typescript": "^7.10.4",
@@ -56,6 +57,7 @@
     "webpack-merge": "^5.2.0"
   },
   "dependencies": {
+    "@babel/runtime": "^7.11.2",
     "cssnano": "^4.1.10",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",


### PR DESCRIPTION
Add `@babel/plugin-transform-runtime` to make async/await work. Without this change, using async functions results in errors about `regeneratorRuntime` not being defined. Now I'm wondering what other subtle things are broken because I didn't know to include some plugin.

The code in this repo doesn't use async/await, but almost certainly a real project of mine would.

BTW, [this thread](https://github.com/babel/babel/issues/9849) helped me figure out the solution.